### PR TITLE
Forceignore Updates

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -4,6 +4,16 @@
 
 package.xml
 
+# These metadata files are ignored when promoting (deploying)
+**/layouts/**
+**/profiles/**
+**/permissionsets/**
+
+# These metadata files are ignored when pulling (retrieving)
+*.layout
+*.profile
+*.permissionset
+
 # LWC configuration files
 **/jsconfig.json
 **/.eslintrc.json


### PR DESCRIPTION
- Updated forceignore to omit Profiles, Permission Sets, and Layouts from deployments. These metadata types always tend to cause deployment errors, since DevOps Center is not smart enough to only deploy meta data types included in a deployment